### PR TITLE
packer and config bump - enable setup of ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 env:
   global:
     - BUILDER: packer
-    - BUILDER_VERSION: 1.5.1
+    - BUILDER_VERSION: 1.6.0
     - OS_ARCH: linux_amd64
   jobs:
     - BOX: ubuntu-1804

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 
 language: python
 python:
-  - "3.7"
+  - "3.8"
 
 env:
   global:

--- a/ubuntu-1604/template-branch-master.json
+++ b/ubuntu-1604/template-branch-master.json
@@ -34,7 +34,7 @@
             "<enter><wait>"
          ],
          "boot_wait":"10s",
-         "disk_size":40960,
+         "disk_size":61440,
          "guest_os_type":"Ubuntu_64",
          "headless":true,
          "http_directory":"http",
@@ -45,7 +45,7 @@
          "ssh_username":"vagrant",
          "ssh_password":"password",
          "ssh_port":22,
-         "ssh_wait_timeout":"12000s",
+         "ssh_wait_timeout":"2000s",
          "shutdown_command":"echo 'vagrant'|sudo -S shutdown -P now",
          "guest_additions_path":"VBoxGuestAdditions_{{.Version}}.iso",
          "virtualbox_version_file":".vbox_version",

--- a/ubuntu-1604/template-branch-master.json
+++ b/ubuntu-1604/template-branch-master.json
@@ -8,9 +8,10 @@
       {
          "type":"virtualbox-iso",
          "boot_command":[
-            "<esc><wait>",
-            "<esc><wait>",
-            "<enter><wait>",
+            "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+            "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+            "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+            "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
             "/install/vmlinuz<wait>",
             " auto<wait>",
             " console-setup/ask_detect=false<wait>",

--- a/ubuntu-1604/template-branch-master.json
+++ b/ubuntu-1604/template-branch-master.json
@@ -40,8 +40,7 @@
          "iso_urls":[
             "https://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso"
          ],
-         "iso_checksum_type":"sha256",
-         "iso_checksum":"16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
+         "iso_checksum":"sha256:16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
          "ssh_username":"vagrant",
          "ssh_password":"password",
          "ssh_port":22,

--- a/ubuntu-1604/template-branch-others.json
+++ b/ubuntu-1604/template-branch-others.json
@@ -39,8 +39,7 @@
          "iso_urls":[
             "https://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso"
          ],
-         "iso_checksum_type":"sha256",
-         "iso_checksum":"16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
+         "iso_checksum":"sha256:16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
          "ssh_username":"vagrant",
          "ssh_password":"password",
          "ssh_port":22,

--- a/ubuntu-1604/template-branch-others.json
+++ b/ubuntu-1604/template-branch-others.json
@@ -24,7 +24,7 @@
             " keyboard-configuration/variant=USA<wait>",
             " locale=en_US<wait>",
             " netcfg/get_domain=ubuntu1604.com<wait>",
-            " netcfg/get_hostname=devops<wait>",
+            " netcfg/get_hostname=ansible<wait>",
             " grub-installer/bootdev=/dev/sda<wait>",
             " noapic<wait>",
             " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",

--- a/ubuntu-1804/template-branch-master.json
+++ b/ubuntu-1804/template-branch-master.json
@@ -2,7 +2,7 @@
    "variables":{
       "cloud_token":"{{ env `VAGRANT_CLOUD_TOKEN` }}",
       "version":"1.0.{{timestamp}}",
-      "release_description":"Latest Ubuntu packages."
+      "release_description":"Latest kernel and package updates."
    },
    "builders":[
       {
@@ -40,8 +40,7 @@
          "iso_urls":[
             "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso"
          ],
-         "iso_checksum_type":"sha256",
-         "iso_checksum":"e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b",
+         "iso_checksum":"sha256:e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b",
          "ssh_username":"vagrant",
          "ssh_password":"password",
          "ssh_port":22,

--- a/ubuntu-1804/template-branch-others.json
+++ b/ubuntu-1804/template-branch-others.json
@@ -38,8 +38,7 @@
          "iso_urls":[
             "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso"
          ],
-         "iso_checksum_type":"sha256",
-         "iso_checksum":"e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b",
+         "iso_checksum":"sha256:e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b",
          "ssh_username":"vagrant",
          "ssh_password":"password",
          "ssh_port":22,


### PR DESCRIPTION
* Bump packer from 1.5.1 to 1.6.0
* Config updates for packer build files of:
- [x] Ubuntu 16.04
- [x] Ubuntu 20.04
* Build a vagrant box for Ubuntu 16.04 LTS (xenial)